### PR TITLE
OpensslPkg/BaseCryptLib: Fix Pkcs7GetCertificatesList clobbering NewP…

### DIFF
--- a/OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c
+++ b/OpensslPkg/Library/BaseCryptLib/Pk/CryptPkcs7VerifyCommon.c
@@ -465,6 +465,7 @@ Pkcs7GetCertificatesList (
 {
   BOOLEAN         Status;
   UINT8           *NewP7Data;
+  CONST UINT8     *Temp;        // MU_CHANGE
   UINTN           NewP7Length;
   BOOLEAN         Wrapped;
   UINT8           Index;
@@ -528,7 +529,10 @@ Pkcs7GetCertificatesList (
   //
   // Decodes PKCS#7 SignedData
   //
-  Pkcs7 = d2i_PKCS7 (NULL, (const unsigned char **)&NewP7Data, (int)NewP7Length);
+  // MU_CHANGE [BEGIN]
+  Temp  = NewP7Data;
+  Pkcs7 = d2i_PKCS7 (NULL, (const unsigned char **)&Temp, (int)NewP7Length);
+  // MU_CHANGE [END]
   if ((Pkcs7 == NULL) || (!PKCS7_type_is_signed (Pkcs7))) {
     goto _Error;
   }


### PR DESCRIPTION
Fix Pkcs7GetCertificatesList clobbering NewP7Data

## Description

d2i_PKCS7 advances the pointer passed to it past the consumed bytes. Pkcs7GetCertificatesList was passing &NewP7Data directly, so after the call NewP7Data no longer pointed at the start of the malloc-allocated wrap buffer.  The subsequent free(NewP7Data) therefore tried to free from the middle of the buffer, causing a heap error at runtime.

Fix by introducing a local Temp pointer for d2i_PKCS7 (matching the pattern already used correctly in Pkcs7GetSigners), so NewP7Data retains the original malloc base address and can be safely freed.


<_Include a description of the change and why this change was made._>

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
